### PR TITLE
little things

### DIFF
--- a/client/actions.lua
+++ b/client/actions.lua
@@ -127,12 +127,16 @@ RegisterNetEvent('ps-adminmenu:client:CopyCoords', function(inputData, buttonlab
     local data = ""
     if buttonlable == "Copy Vector2" then
         data = string.format('vector2(%s, %s)', x, y)
+        QBCore.Functions.Notify(Lang:t("success.copy_vector2"), "success", 5000)
     elseif buttonlable == "Copy Vector3" then
         data = string.format('vector3(%s, %s, %s)', x, y, z)
+        QBCore.Functions.Notify(Lang:t("success.copy_vector3"), "success", 5000)
     elseif buttonlable == "Copy Vector4" then
         data = string.format('vector4(%s, %s, %s, %s)', x, y, z, h)
+        QBCore.Functions.Notify(Lang:t("success.copy_vector4"), "success", 5000)
     elseif buttonlable == "Copy Heading" then
         data = h
+        QBCore.Functions.Notify(Lang:t("success.copy_heading"), "success", 5000)
     end
 
     SendNUIMessage({
@@ -268,6 +272,29 @@ RegisterNetEvent('ps-adminmenu:client:openInventory', function(inputData)
     elseif inv == "ox" then
         TriggerServerEvent("ps-adminmenu:server:OpenInv", playerid)
     end
+end)
+
+-- Spawn Vehicle
+RegisterNetEvent('ps-adminmenu:client:SpawnVehicle', function(inputData)
+    local ped = PlayerPedId()
+    local hash = GetHashKey(inputData["Vehicle"])
+    local veh = GetVehiclePedIsUsing(ped)
+    if not IsModelInCdimage(hash) then return end
+    RequestModel(hash)
+    while not HasModelLoaded(hash) do
+        Wait(0)
+    end
+
+    if IsPedInAnyVehicle(ped) then
+        DeleteVehicle(veh)
+    end
+
+    local vehicle = CreateVehicle(hash, GetEntityCoords(ped), GetEntityHeading(ped), true, false)
+    TaskWarpPedIntoVehicle(ped, vehicle, -1)
+    exports[Config.FuelScript]:SetFuel(vehicle, 100.0)
+    SetVehicleDirtLevel(vehicle, 0.0)
+    SetModelAsNoLongerNeeded(hash)
+    TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(vehicle))
 end)
 
 -- noclip

--- a/client/main.lua
+++ b/client/main.lua
@@ -28,6 +28,8 @@ RegisterCommand("admin", function()
     
 end, false)
 
+RegisterKeyMapping('admin', 'Open Adminmenu', 'keyboard', 'U') -- https://docs.fivem.net/docs/game-references/controls/
+
 
 RegisterNUICallback("hideUI", function()
     toggleUI(false)

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -17,6 +17,10 @@ local Translations = {
         ["deFrozen"] = "You've set %{player} free",
         ["noclip_enabled"] = "No-clip enabled",
         ["noclip_disabled"] = "No-clip disabled",
+        ["copy_vector2"] = "Copied vector2",
+        ["copy_vector3"] = "Copied vector3",
+        ["copy_vector4"] = "Copied vector4",
+        ["copy_heading"] = "Copied heading",
     },
     info = {
         ["godmode"] = "Godmode is %{value}",

--- a/server/server.lua
+++ b/server/server.lua
@@ -59,13 +59,6 @@ QBCore.Functions.CreateCallback('ps-adminmenu:server:GetPlayers', function(_, cb
     cb(Players)
 end)
 
-
--- Spawn Vehicle
-RegisterNetEvent('ps-adminmenu:server:SpawnVehicle', function(inputData)
-    local vehicle = inputData["Vehicle"]
-    TriggerClientEvent('QBCore:Command:SpawnVehicle', source, vehicle)
-end)
-
 -- Admin Car
 RegisterNetEvent('ps-adminmenu:server:SaveCar', function(mods, vehicle, _, plate)
     local src = source

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -2,6 +2,8 @@ Config = {}
 
 Config.InventoryUsage =  "lj" -- qb(for qb-inventory) lj(for lj-inventory) or ox(for ox_inventory) [Inventory system]
 
+Config.FuelScript =  "LegacyFuel" -- LegacyFuel / qb-fuel / ps-fuel / lj-fuel [Car spawning/fixing]
+
 Config.Actions = {
     { 
         label = "Admin car", -- Label of the button
@@ -280,8 +282,14 @@ Config.Actions = {
         perms = "mod", 
         dropdown = {
             { label = "Vehicle", InputType = "input" },
-            { label = "Sumbit", InputType = "button", type = "server", event = "ps-adminmenu:server:SpawnVehicle" },
+            { label = "Sumbit", InputType = "button", type = "client", event = "ps-adminmenu:client:SpawnVehicle" },
         },
+    },
+    { 
+        label = "Fix Vehicle",
+        event = "fix",
+        type = "command",
+        perms = "mod",
     },
     { 
         label = "Specate Player", 


### PR DESCRIPTION
- edited spawn vehicle remove the server event that only trigger the command ( setfuel doesnt work) added client side event thats the same as the command but with SetFuel export for ps-fuel / lj-fuel and so on
- added Config.FuelScript for that export to work -- default is LegacyFuel
- added RegisterKeyMapping for the adminmenu -- default is U
- added Notify and locales for when vectors or heading getting copied
- added fix vehicle option