### PR TITLE
Clear Resources Table Before Adding New Resources

### DIFF
--- a/server/resources.lua
+++ b/server/resources.lua
@@ -2,7 +2,9 @@ local resources = {}
 
 lib.callback.register('ps-adminmenu:callback:GetResources', function(source)
     local totalResources = GetNumResources()
-
+        
+    resources = {}
+        
     for i = 0, totalResources - 1 do
         local resourceName = GetResourceByFindIndex(i)
         local author = GetResourceMetadata(resourceName, "author")


### PR DESCRIPTION
Fixed the issue of duplicate resources appearing in the menu. The root cause of this issue was that the resources table was not being cleared before new resources were added. As a result, every time the ps-adminmenu:callback:GetResources function was called, new resources were added to the resources table without removing the old ones, leading to duplicates.

**Changes made:**

- Added a line to clear the resources table at the start of the ps-adminmenu:callback:GetResources function. This ensures that the resources table only contains the current resources every time the function is called.