### PR TITLE
Fix ToggleDev event which was passing through wrong parameter

### DIFF
--- a/client/misc.lua
+++ b/client/misc.lua
@@ -157,15 +157,15 @@ end, false)
 --Toggle Dev
 local ToggleDev = false
 
-RegisterNetEvent('ps-adminmenu:client:ToggleDev', function(data)
-    local data = CheckDataFromKey(data)
+RegisterNetEvent('ps-adminmenu:client:ToggleDev', function(dataKey)
+    local data = CheckDataFromKey(dataKey)
     if not data or not CheckPerms(data.perms) then return end
 
     ToggleDev = not ToggleDev
 
-    TriggerEvent("qb-admin:client:ToggleDevmode")           -- toggle dev mode (ps-hud/qb-hud)
-    TriggerEvent('ps-adminmenu:client:ToggleCoords', data)  -- toggle Coords
-    TriggerEvent('ps-adminmenu:client:ToggleGodmode', data) -- Godmode
+    TriggerEvent("qb-admin:client:ToggleDevmode")              -- toggle dev mode (ps-hud/qb-hud)
+    TriggerEvent('ps-adminmenu:client:ToggleCoords', dataKey)  -- toggle Coords
+    TriggerEvent('ps-adminmenu:client:ToggleGodmode', dataKey) -- Godmode
 
     QBCore.Functions.Notify(locale("toggle_dev"), 'success')
 end)


### PR DESCRIPTION
When enabling "dev" mode the expected coords + invincibility events aren't being executed. This is because `data` which has the value of `toggleDevmode` when first evaluated is replaced by the table from configuration. 

That same `data` table is then forwarded on to other events which are performing the same check, although they are only expecting the original key to be sent.

Fix is simply forwarding the appropriate key to subsequent events.