### PR TITLE
fix(ps-adminmenu): load players on menu open

### DIFF
--- a/ui/src/layout/Main.svelte
+++ b/ui/src/layout/Main.svelte
@@ -8,6 +8,14 @@
 	import StaffChat from '@pages/Chat/Chat.svelte'
 	import Players from '@pages/Players/Players.svelte'
 	import Commands from '@pages/Commands/Commands.svelte'
+	import { onMount } from 'svelte'
+	import { SendNUI } from '@utils/SendNUI'
+	import { PLAYER } from '@store/players'
+
+	onMount(async () => {
+		const players = await SendNUI('getPlayers')
+		PLAYER.set(players)
+	})
 </script>
 
 <div


### PR DESCRIPTION
…ions

load players on menu open to avoid freezing on actions. Currently if you don't open players before you open actions then your menu will freeze your NUI and require a script or game restart.