### PR TITLE
Security problem: cheaters can exploit it.

### DIFF
--- a/client/inventory.lua
+++ b/client/inventory.lua
@@ -1,7 +1,5 @@
 -- Open Inventory
 RegisterNetEvent('ps-adminmenu:client:openInventory', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local player = selectedData["Player"].value
 
     if Config.Inventory == 'ox_inventory' then
@@ -13,8 +11,6 @@ end)
 
 -- Open Stash
 RegisterNetEvent('ps-adminmenu:client:openStash', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local stash = selectedData["Stash"].value
 
     if Config.Inventory == 'ox_inventory' then
@@ -27,8 +23,6 @@ end)
 
 -- Open Trunk
 RegisterNetEvent('ps-adminmenu:client:openTrunk', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local vehiclePlate = selectedData["Plate"].value
 
     if Config.Inventory == 'ox_inventory' then

--- a/client/main.lua
+++ b/client/main.lua
@@ -39,10 +39,10 @@ RegisterNUICallback("clickButton", function(data)
 	local selectedData = data.selectedData
 	local key = data.data
 	local data = CheckDataFromKey(key)
-	if not data or not CheckPerms(data.perms) then return end
+	if not data then return end
 
 	if data.type == "client" then
-		TriggerEvent(data.event, key, selectedData)
+		TriggerServerEvent('ps-adminmenu:server:ValidateClientAction', key, selectedData, data.event, data.perms)
 	elseif data.type == "server" then
 		TriggerServerEvent(data.event, key, selectedData)
 	elseif data.type == "command" then

--- a/client/misc.lua
+++ b/client/misc.lua
@@ -1,18 +1,13 @@
 -- Toggles Invincibility
 local visible = true
 RegisterNetEvent('ps-adminmenu:client:ToggleInvisible', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     visible = not visible
-
     SetEntityVisible(cache.ped, visible, 0)
 end)
 
 -- God Mode
 local godmode = false
 RegisterNetEvent('ps-adminmenu:client:ToggleGodmode', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     godmode = not godmode
 
     if godmode then
@@ -55,30 +50,28 @@ local function CopyCoords(data)
 end
 
 RegisterCommand("vector2", function()
-    if not CheckPerms('mod') then return end
-    CopyCoords("vector2")
+    TriggerServerEvent('ps-adminmenu:server:ValidateCommand', 'vector2', 'mod')
 end, false)
 
 RegisterCommand("vector3", function()
-    if not CheckPerms('mod') then return end
-    CopyCoords("vector3")
+    TriggerServerEvent('ps-adminmenu:server:ValidateCommand', 'vector3', 'mod')
 end, false)
 
 RegisterCommand("vector4", function()
-    if not CheckPerms('mod') then return end
-    CopyCoords("vector4")
+    TriggerServerEvent('ps-adminmenu:server:ValidateCommand', 'vector4', 'mod')
 end, false)
 
 RegisterCommand("heading", function()
-    if not CheckPerms('mod') then return end
-    CopyCoords("heading")
+    TriggerServerEvent('ps-adminmenu:server:ValidateCommand', 'heading', 'mod')
 end, false)
+
+RegisterNetEvent('ps-adminmenu:client:CopyCoords', function(type)
+    CopyCoords(type)
+end)
 
 -- Infinite Ammo
 local InfiniteAmmo = false
 RegisterNetEvent('ps-adminmenu:client:setInfiniteAmmo', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     InfiniteAmmo = not InfiniteAmmo
 
     if GetAmmoInPedWeapon(cache.ped, cache.weapon) < 6 then
@@ -116,9 +109,6 @@ local function showCoordsMenu()
 end
 
 RegisterNetEvent('ps-adminmenu:client:ToggleCoords', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     showCoords = not showCoords
 
     if showCoords then
@@ -128,9 +118,6 @@ end)
 
 -- Set Ammo
 RegisterNetEvent('ps-adminmenu:client:SetAmmo', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     local ammo = selectedData["Ammo Amount"].value
     local weapon = GetSelectedPedWeapon(cache.ped)
 
@@ -142,8 +129,11 @@ RegisterNetEvent('ps-adminmenu:client:SetAmmo', function(data, selectedData)
     end
 end)
 
-RegisterCommand("setammo", function(source)
-    if not CheckPerms('mod') then return end
+RegisterCommand("setammo", function()
+    TriggerServerEvent('ps-adminmenu:server:ValidateCommand', 'setammo', 'mod')
+end, false)
+
+RegisterNetEvent('ps-adminmenu:client:SetAmmoCommand', function()
     local weapon = GetSelectedPedWeapon(cache.ped)
     local ammo = 999
     if weapon ~= nil then
@@ -152,15 +142,12 @@ RegisterCommand("setammo", function(source)
     else
         QBCore.Functions.Notify(locale("no_weapon"), 'error')
     end
-end, false)
+end)
 
 --Toggle Dev
 local ToggleDev = false
 
 RegisterNetEvent('ps-adminmenu:client:ToggleDev', function(dataKey)
-    local data = CheckDataFromKey(dataKey)
-    if not data or not CheckPerms(data.perms) then return end
-
     ToggleDev = not ToggleDev
 
     TriggerEvent("qb-admin:client:ToggleDevmode")              -- toggle dev mode (ps-hud/qb-hud)
@@ -182,7 +169,7 @@ local toogleAdmin = lib.addKeybind({
 
 --noclip
 RegisterCommand('nc', function()
-    TriggerEvent(Config.Actions["noclip"].event)
+    TriggerServerEvent('ps-adminmenu:server:ValidateClientAction', 'noclip', nil, Config.Actions["noclip"].event, Config.Actions["noclip"].perms)
 end, false)
 
 local toogleNoclip = lib.addKeybind({

--- a/client/noclip.lua
+++ b/client/noclip.lua
@@ -200,7 +200,6 @@ local function ToggleNoclip()
 end
 
 RegisterNetEvent('ps-adminmenu:client:ToggleNoClip', function()
-    if not CheckPerms(Config.Actions["noclip"].perms) then return end
     ToggleNoclip()
 end)
 

--- a/client/players.lua
+++ b/client/players.lua
@@ -144,23 +144,17 @@ end
 
 -- Toggle Blips and Names events
 RegisterNetEvent('ps-adminmenu:client:toggleBlips', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     if not ShowBlips then preparePlayers() end
     ToggleBlipsAndNames(true)
 end)
 
 RegisterNetEvent('ps-adminmenu:client:toggleNames', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     if not ShowNames then preparePlayers() end
     ToggleBlipsAndNames(false)
 end)
 
 -- Mute Player
 RegisterNetEvent("ps-adminmenu:client:MutePlayer", function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local playerId = selectedData["Player"].value
     if not playerId then return end
     exports["pma-voice"]:toggleMutePlayer(playerId)

--- a/client/teleport.lua
+++ b/client/teleport.lua
@@ -16,9 +16,6 @@ end)
 
 -- Teleport to coords
 RegisterNetEvent('ps-adminmenu:client:TeleportToCoords', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     local coordsStr = selectedData["Coords"].value
     local x, y, z, heading
 
@@ -44,8 +41,6 @@ end)
 
 -- Teleport to Locaton
 RegisterNetEvent('ps-adminmenu:client:TeleportToLocation', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local coords = selectedData["Location"].value
 
     lastCoords = GetEntityCoords(cache.ped)
@@ -54,9 +49,6 @@ end)
 
 -- Teleport back
 RegisterNetEvent('ps-adminmenu:client:TeleportBack', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     if lastCoords then
         local coords = GetEntityCoords(cache.ped)
         teleport(lastCoords.x, lastCoords.y, lastCoords.z)

--- a/client/troll.lua
+++ b/client/troll.lua
@@ -20,8 +20,6 @@ end)
 
 -- Play Sound
 RegisterNetEvent('ps-adminmenu:client:PlaySound', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local player = selectedData["Player"].value
     local sound = selectedData["Sound"].value
 

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -7,11 +7,6 @@ function ToggleUI(bool)
 	})
 end
 
---- @param perms table
-function CheckPerms(perms)
-	return lib.callback.await('ps-adminmenu:callback:CheckPerms', false, perms)
-end
-
 function CheckDataFromKey(key)
 	local actions = Config.Actions[key]
 	if actions then

--- a/client/vehicles.lua
+++ b/client/vehicles.lua
@@ -8,9 +8,6 @@ end
 
 -- Own Vehicle
 RegisterNetEvent('ps-adminmenu:client:Admincar', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     if not cache.vehicle then return end
 
     local props = lib.getVehicleProperties(cache.vehicle)
@@ -27,9 +24,6 @@ end)
 
 -- Spawn Vehicle
 RegisterNetEvent('ps-adminmenu:client:SpawnVehicle', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     local selectedVehicle = selectedData["Vehicle"].value
     local hash = GetHashKey(selectedVehicle)
 
@@ -57,9 +51,6 @@ end)
 
 -- Refuel Vehicle
 RegisterNetEvent('ps-adminmenu:client:RefuelVehicle', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     if cache.vehicle then
         if Config.Fuel == "ox_fuel" then
             Entity(cache.vehicle).state.fuel = 100.0
@@ -74,8 +65,6 @@ end)
 
 -- Change plate
 RegisterNetEvent('ps-adminmenu:client:ChangePlate', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local plate = selectedData["Plate"].value
 
     if string.len(plate) > 8 then
@@ -129,8 +118,6 @@ local function UpdateVehicleMenu()
 end
 
 RegisterNetEvent('ps-adminmenu:client:ToggleVehDevMenu', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     if not cache.vehicle then return end
 
     VEHICLE_DEV_MODE = not VEHICLE_DEV_MODE
@@ -157,9 +144,6 @@ end
 
 
 RegisterNetEvent('ps-adminmenu:client:maxmodVehicle', function(data)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     if cache.vehicle then
         UpgradePerformance(cache.vehicle)
     else
@@ -170,9 +154,6 @@ end)
 -- Spawn Personal vehicles
 
 RegisterNetEvent("ps-adminmenu:client:SpawnPersonalVehicle", function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     local plate = selectedData['VehiclePlate'].value
     local ped = PlayerPedId()
     local coords = QBCore.Functions.GetCoords(ped)

--- a/client/vehicles.lua
+++ b/client/vehicles.lua
@@ -19,7 +19,7 @@ RegisterNetEvent('ps-adminmenu:client:Admincar', function(data)
     local hash = GetHashKey(cache.vehicle)
 
     if sharedVehicles then
-        TriggerServerEvent('ps-adminmenu:server:SaveCar', props, sharedVehicles, hash, props.plate)
+        TriggerServerEvent('ps-adminmenu:server:SaveCar', data, props, sharedVehicles, hash, props.plate)
     else
         QBCore.Functions.Notify(locale("cannot_store_veh"), 'error')
     end

--- a/client/world.lua
+++ b/client/world.lua
@@ -1,7 +1,5 @@
 -- Changes the time
 RegisterNetEvent('ps-adminmenu:client:ChangeTime', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local time = selectedData["Time Events"].value
 
     if not time then return end
@@ -11,17 +9,12 @@ end)
 
 -- Changes the weather
 RegisterNetEvent('ps-adminmenu:client:ChangeWeather', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
     local weather = selectedData["Weather"].value
 
     TriggerServerEvent('qb-weathersync:server:setWeather', weather)
 end)
 
 RegisterNetEvent('ps-adminmenu:client:copyToClipboard', function(data, selectedData)
-    local data = CheckDataFromKey(data)
-    if not data or not CheckPerms(data.perms) then return end
-
     local dropdown = selectedData["Copy Coords"].value
     local ped = PlayerPedId()
     local string = nil

--- a/server/main.lua
+++ b/server/main.lua
@@ -7,4 +7,20 @@ lib.addCommand('admin', {
     if not QBCore.Functions.IsOptin(source) then TriggerClientEvent('QBCore:Notify', source, 'You are not on admin duty', 'error'); return end
     TriggerClientEvent('ps-adminmenu:client:OpenUI', source)
 end)
--- Callbacks
+
+RegisterNetEvent('ps-adminmenu:server:ValidateClientAction', function(key, selectedData, event, perms)
+    local src = source
+    if not CheckPerms(src, perms) then return end
+    TriggerClientEvent(event, src, key, selectedData)
+end)
+
+RegisterNetEvent('ps-adminmenu:server:ValidateCommand', function(command, perms)
+    local src = source
+    if not CheckPerms(src, perms) then return end
+    
+    if command == 'vector2' or command == 'vector3' or command == 'vector4' or command == 'heading' then
+        TriggerClientEvent('ps-adminmenu:client:CopyCoords', src, command)
+    elseif command == 'setammo' then
+        TriggerClientEvent('ps-adminmenu:client:SetAmmoCommand', src)
+    end
+end)

--- a/server/vehicle.lua
+++ b/server/vehicle.lua
@@ -1,12 +1,6 @@
 -- Admin Car
-RegisterNetEvent('ps-adminmenu:server:SaveCar', function(data, mods, vehicle, _, plate)
+RegisterNetEvent('ps-adminmenu:server:SaveCar', function(mods, vehicle, _, plate)
     local src = source
-    
-    if not data or not CheckPerms(src, data.perms) then
-        QBCore.Functions.Notify(src, locale("no_perms"), "error", 5000)
-        return
-    end
-    
     local Player = QBCore.Functions.GetPlayer(src)
     local result = MySQL.query.await('SELECT plate FROM player_vehicles WHERE plate = ?', { plate })
 

--- a/server/vehicle.lua
+++ b/server/vehicle.lua
@@ -1,6 +1,12 @@
 -- Admin Car
-RegisterNetEvent('ps-adminmenu:server:SaveCar', function(mods, vehicle, _, plate)
+RegisterNetEvent('ps-adminmenu:server:SaveCar', function(data, mods, vehicle, _, plate)
     local src = source
+    
+    if not data or not CheckPerms(src, data.perms) then
+        QBCore.Functions.Notify(src, locale("no_perms"), "error", 5000)
+        return
+    end
+    
     local Player = QBCore.Functions.GetPlayer(src)
     local result = MySQL.query.await('SELECT plate FROM player_vehicles WHERE plate = ?', { plate })
 


### PR DESCRIPTION
You can never trust the client, using the client to check permissions is bad, it shouldn't be done, which is what admin menu do in the client TriggerServerEvent('ps-adminmenu:server:SaveCar', props, sharedVehicles, hash, props.plate), I simply added a check to the server, without this update a cheater can easily put an infinite number of cars in the garage.